### PR TITLE
Tweak Docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,7 @@ version: "3"
 
 services:
   misskey-ebooks-bot:
-    build:
-      context: ./
+    image: fotoente/misskey-ebooks-bot
     container_name: misskey-ebooks-bot
     restart: always
     volumes:


### PR DESCRIPTION
Tweak Docker compose file:
- Use image instead of building so users don't have to download the repo or build on their machine